### PR TITLE
[DTLS] Fix for issue 21

### DIFF
--- a/DTLS/Program.cs
+++ b/DTLS/Program.cs
@@ -75,7 +75,7 @@ namespace DTLS.Types
             else if (args.Length == 0)
                 PrintUsage();
 
-            Logstream.Close();
+            if(Logstream != null) Logstream.Close();
         }
         private static void PrintUsage()
         {


### PR DESCRIPTION
When no arguments are given, variable Logstream is not initialized, causing an error when the program attempts to exit.
