### PR TITLE
Table shows selected node, instead of needing a double-click to switch

### DIFF
--- a/AnimCmd/Gui/CodeEditControl.cs
+++ b/AnimCmd/Gui/CodeEditControl.cs
@@ -43,7 +43,7 @@ namespace Sm4shCommand
         }
 
         private uint unkParam0;
-        private uint UnkParam1;
+        private uint unkParam1;
         private uint IASAFrame;
         private uint unkParam3;
         private uint unkParam4;

--- a/DTLS/IO/FileMap.cs
+++ b/DTLS/IO/FileMap.cs
@@ -52,7 +52,7 @@ namespace System.IO
                 stream = new FileStream(tempPath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 8, options | FileOptions.DeleteOnClose);
             }
             try { map = FromStreamInternal(stream, prot, offset, length); }
-            catch (Exception x) { stream.Dispose(); throw; }
+            catch (Exception) { stream.Dispose(); throw; }
             map._path = path; //In case we're using a temp file
             stream.Dispose();
             return map;
@@ -61,7 +61,7 @@ namespace System.IO
         {
             FileStream stream = new FileStream(Path.GetTempFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 8, FileOptions.RandomAccess | FileOptions.DeleteOnClose);
             try { FileMap m = FromStreamInternal(stream, FileMapProtect.ReadWrite, 0, length); stream.Dispose(); return m; }
-            catch (Exception x) { stream.Dispose(); throw; }
+            catch (Exception) { stream.Dispose(); throw; }
         }
 
         public static FileMap FromStream(FileStream stream) { return FromStream(stream, FileMapProtect.ReadWrite, 0, 0); }
@@ -70,7 +70,7 @@ namespace System.IO
         {
             //FileStream newStream = new FileStream(stream.Name, FileMode.Open, prot == FileMapProtect.Read ? FileAccess.Read : FileAccess.ReadWrite, FileShare.Read, 8, FileOptions.RandomAccess);
             //try { return FromStreamInternal(newStream, prot, offset, length); }
-            //catch (Exception x) { newStream.Dispose(); throw x; }
+            //catch (Exception) { newStream.Dispose(); throw; }
 
             if (length == 0)
                 length = (int)stream.Length;

--- a/Noah/N0aH.csproj
+++ b/Noah/N0aH.csproj
@@ -61,7 +61,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/PACKManager/IO/FileMap.cs
+++ b/PACKManager/IO/FileMap.cs
@@ -52,7 +52,7 @@ namespace System.IO
                 stream = new FileStream(tempPath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 8, options | FileOptions.DeleteOnClose);
             }
             try { map = FromStreamInternal(stream, prot, offset, length); }
-            catch (Exception x) { stream.Dispose(); throw x; }
+            catch (Exception) { stream.Dispose(); throw; }
             map._path = path; //In case we're using a temp file
             return map;
         }
@@ -60,7 +60,7 @@ namespace System.IO
         {
             FileStream stream = new FileStream(Path.GetTempFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 8, FileOptions.RandomAccess | FileOptions.DeleteOnClose);
             try { return FromStreamInternal(stream, FileMapProtect.ReadWrite, 0, length); }
-            catch (Exception x) { stream.Dispose(); throw x; }
+            catch (Exception) { stream.Dispose(); throw; }
         }
 
         public static FileMap FromStream(FileStream stream) { return FromStream(stream, FileMapProtect.ReadWrite, 0, 0); }
@@ -69,7 +69,7 @@ namespace System.IO
         {
             //FileStream newStream = new FileStream(stream.Name, FileMode.Open, prot == FileMapProtect.Read ? FileAccess.Read : FileAccess.ReadWrite, FileShare.Read, 8, FileOptions.RandomAccess);
             //try { return FromStreamInternal(newStream, prot, offset, length); }
-            //catch (Exception x) { newStream.Dispose(); throw x; }
+            //catch (Exception) { newStream.Dispose(); throw; }
 
             if (length == 0)
                 length = (int)stream.Length;

--- a/PARAM/Form1.Designer.cs
+++ b/PARAM/Form1.Designer.cs
@@ -104,12 +104,13 @@
             // treeView1
             // 
             this.treeView1.Dock = System.Windows.Forms.DockStyle.Left;
+            this.treeView1.HideSelection = false;
             this.treeView1.Location = new System.Drawing.Point(0, 24);
             this.treeView1.Name = "treeView1";
             this.treeView1.Size = new System.Drawing.Size(121, 507);
             this.treeView1.TabIndex = 4;
+            this.treeView1.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.treeView1_AfterSelect);
             this.treeView1.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.treeView1_NodeMouseClick);
-            this.treeView1.NodeMouseDoubleClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.treeView1_NodeMouseDoubleClick);
             // 
             // Form1
             // 

--- a/PARAM/Form1.cs
+++ b/PARAM/Form1.cs
@@ -95,7 +95,7 @@ namespace Parameters
             }
         }
 
-        private void treeView1_NodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e)
+        private void treeView1_AfterSelect(object sender, TreeViewEventArgs e)
         {
             var node = e.Node as ValuesWrapper;
             if (node is GroupWrapper)

--- a/SALT/SALT.csproj
+++ b/SALT/SALT.csproj
@@ -39,7 +39,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/SALT/System/IO/FileMap.cs
+++ b/SALT/System/IO/FileMap.cs
@@ -52,7 +52,7 @@ namespace System.IO
                 stream = new FileStream(tempPath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 8, options | FileOptions.DeleteOnClose);
             }
             try { map = FromStreamInternal(stream, prot, offset, length); }
-            catch (Exception x) { stream.Dispose(); throw; }
+            catch (Exception) { stream.Dispose(); throw; }
             map._path = path; //In case we're using a temp file
             stream.Dispose();
             return map;
@@ -61,7 +61,7 @@ namespace System.IO
         {
             FileStream stream = new FileStream(Path.GetTempFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 8, FileOptions.RandomAccess | FileOptions.DeleteOnClose);
             try { FileMap m = FromStreamInternal(stream, FileMapProtect.ReadWrite, 0, length); stream.Dispose(); return m; }
-            catch (Exception x) { stream.Dispose(); throw; }
+            catch (Exception) { stream.Dispose(); throw; }
         }
 
         public static FileMap FromStream(FileStream stream) { return FromStream(stream, FileMapProtect.ReadWrite, 0, 0); }
@@ -70,7 +70,7 @@ namespace System.IO
         {
             //FileStream newStream = new FileStream(stream.Name, FileMode.Open, prot == FileMapProtect.Read ? FileAccess.Read : FileAccess.ReadWrite, FileShare.Read, 8, FileOptions.RandomAccess);
             //try { return FromStreamInternal(newStream, prot, offset, length); }
-            //catch (Exception x) { newStream.Dispose(); throw x; }
+            //catch (Exception) { newStream.Dispose(); throw; }
 
             if (length == 0)
                 length = (int)stream.Length;


### PR DESCRIPTION
This makes it so the table is always showing the node that is selected in the tree view, rather than requiring a double-click to switch.

This let me use the arrow keys to move up and down and easily see the different values that were used for different elements.

Also set the tree view's HideSelection to false, so you can still see which element in it is selected when the table view has the focus.

Plus a few warnings fixed - the System.Net.Http references were removed, since they weren't used and couldn't be found. (I think it's part of framework 4.5 and the projects only require 4.0.)  Also, removed the name for some exceptions were that wasn't used, and then switched some where it was used to match.
