### PR TITLE
Fix handling of signed and unsigned param values

### DIFF
--- a/PARAM/Form1.cs
+++ b/PARAM/Form1.cs
@@ -61,23 +61,23 @@ namespace Parameters
                         ParameterType type = (ParameterType)stream.ReadByte();
                         switch (type)
                         {
+                            case ParameterType.s8:
+                                wrp.Parameters.Add(new ParamEntry(reader.ReadSByte(), type));
+                                break;
                             case ParameterType.u8:
                                 wrp.Parameters.Add(new ParamEntry(reader.ReadByte(), type));
-                                break;
-                            case ParameterType.s8:
-                                wrp.Parameters.Add(new ParamEntry(reader.ReadByte(), type));
-                                break;
-                            case ParameterType.u16:
-                                wrp.Parameters.Add(new ParamEntry(reader.ReadUInt16().Reverse(), type));
                                 break;
                             case ParameterType.s16:
                                 wrp.Parameters.Add(new ParamEntry(reader.ReadInt16().Reverse(), type));
                                 break;
-                            case ParameterType.u32:
-                                wrp.Parameters.Add(new ParamEntry(reader.ReadUInt32().Reverse(), type));
+                            case ParameterType.u16:
+                                wrp.Parameters.Add(new ParamEntry(reader.ReadUInt16().Reverse(), type));
                                 break;
                             case ParameterType.s32:
                                 wrp.Parameters.Add(new ParamEntry(reader.ReadInt32().Reverse(), type));
+                                break;
+                            case ParameterType.u32:
+                                wrp.Parameters.Add(new ParamEntry(reader.ReadUInt32().Reverse(), type));
                                 break;
                             case ParameterType.f32:
                                 wrp.Parameters.Add(new ParamEntry(reader.ReadSingle().Reverse(), type));
@@ -124,23 +124,23 @@ namespace Parameters
                 var entry = node.Parameters[i];
                 switch (entry.Type)
                 {
+                    case ParameterType.s8:
+                        tbl.Rows[i][1] = (sbyte)entry.Value;
+                        break;
                     case ParameterType.u8:
                         tbl.Rows[i][1] = (byte)entry.Value;
-                        break;
-                    case ParameterType.s8:
-                        tbl.Rows[i][1] = (byte)entry.Value;
-                        break;
-                    case ParameterType.u16:
-                        tbl.Rows[i][1] = (ushort)entry.Value;
                         break;
                     case ParameterType.s16:
                         tbl.Rows[i][1] = (short)entry.Value;
                         break;
-                    case ParameterType.u32:
-                        tbl.Rows[i][1] = (uint)entry.Value;
+                    case ParameterType.u16:
+                        tbl.Rows[i][1] = (ushort)entry.Value;
                         break;
                     case ParameterType.s32:
                         tbl.Rows[i][1] = (int)entry.Value;
+                        break;
+                    case ParameterType.u32:
+                        tbl.Rows[i][1] = (uint)entry.Value;
                         break;
                     case ParameterType.f32:
                         tbl.Rows[i][1] = (float)entry.Value;
@@ -204,21 +204,23 @@ namespace Parameters
                 object val = null;
                 switch (t)
                 {
-                    case ParameterType.u8:
                     case ParameterType.s8:
-                        val = Convert.ToByte(tbl.Rows[i][1]);
+                        val = Convert.ToSByte(tbl.Rows[i][1]);
                         break;
-                    case ParameterType.u16:
-                        val = Convert.ToUInt16(tbl.Rows[i][1]);
+                    case ParameterType.u8:
+                        val = Convert.ToByte(tbl.Rows[i][1]);
                         break;
                     case ParameterType.s16:
                         val = Convert.ToInt16(tbl.Rows[i][1]);
                         break;
-                    case ParameterType.u32:
-                        val = Convert.ToUInt32(tbl.Rows[i][1]);
+                    case ParameterType.u16:
+                        val = Convert.ToUInt16(tbl.Rows[i][1]);
                         break;
                     case ParameterType.s32:
                         val = Convert.ToInt32(tbl.Rows[i][1]);
+                        break;
+                    case ParameterType.u32:
+                        val = Convert.ToUInt32(tbl.Rows[i][1]);
                         break;
                     case ParameterType.f32:
                         val = Convert.ToSingle(tbl.Rows[i][1]);
@@ -239,12 +241,12 @@ namespace Parameters
 
     public enum ParameterType : byte
     {
-        u8 = 1,
-        s8 = 2,
-        u16 = 3,
-        s16 = 4,
-        u32 = 5,
-        s32 = 6,
+        s8 = 1,
+        u8 = 2,
+        s16 = 3,
+        u16 = 4,
+        s32 = 5,
+        u32 = 6,
         f32 = 7,
         str = 8,
         group = 0x20

--- a/PARAM/GroupWrapper.cs
+++ b/PARAM/GroupWrapper.cs
@@ -94,8 +94,10 @@ namespace Parameters
                     object value = null;
                     switch (type)
                     {
-                        case ParameterType.u8:
                         case ParameterType.s8:
+                            value = (sbyte)int.Parse(dlg.TextVal);
+                            break;
+                        case ParameterType.u8:
                             value = (byte)int.Parse(dlg.TextVal);
                             break;
                         case ParameterType.s16:
@@ -104,11 +106,11 @@ namespace Parameters
                         case ParameterType.u16:
                             value = ushort.Parse(dlg.TextVal);
                             break;
-                        case ParameterType.u32:
-                            value = uint.Parse(dlg.TextVal);
-                            break;
                         case ParameterType.s32:
                             value = int.Parse(dlg.TextVal);
+                            break;
+                        case ParameterType.u32:
+                            value = uint.Parse(dlg.TextVal);
                             break;
                         case ParameterType.f32:
                             value = float.Parse(dlg.TextVal);
@@ -130,23 +132,23 @@ namespace Parameters
             foreach (var t in types)
                 switch (t)
                 {
+                    case ParameterType.s8:
+                        entries.Add(new ParamEntry((sbyte)0, t));
+                        break;
                     case ParameterType.u8:
                         entries.Add(new ParamEntry((byte)0, t));
-                        break;
-                    case ParameterType.s8:
-                        entries.Add(new ParamEntry((byte)0, t));
-                        break;
-                    case ParameterType.u16:
-                        entries.Add(new ParamEntry((ushort)0, t));
                         break;
                     case ParameterType.s16:
                         entries.Add(new ParamEntry((short)0, t));
                         break;
-                    case ParameterType.u32:
-                        entries.Add(new ParamEntry((uint)0, t));
+                    case ParameterType.u16:
+                        entries.Add(new ParamEntry((ushort)0, t));
                         break;
                     case ParameterType.s32:
                         entries.Add(new ParamEntry(0, t));
+                        break;
+                    case ParameterType.u32:
+                        entries.Add(new ParamEntry((uint)0, t));
                         break;
                     case ParameterType.f32:
                         entries.Add(new ParamEntry((float)0, t));

--- a/PARAM/ParamEntry.cs
+++ b/PARAM/ParamEntry.cs
@@ -19,20 +19,20 @@ namespace Parameters
         {
             get
             {
-                switch (Type)
+                switch (this.Type)
                 {
-                    case ParameterType.u8:
                     case ParameterType.s8:
+                    case ParameterType.u8:
                         return 2;
-                    case ParameterType.u16:
                     case ParameterType.s16:
+                    case ParameterType.u16:
                         return 3;
-                    case ParameterType.u32:
                     case ParameterType.s32:
+                    case ParameterType.u32:
                     case ParameterType.f32:
                         return 5;
                     case ParameterType.str:
-                        return ((string)Value).Length + 1;
+                        return ((string)this.Value).Length + 1;
                     default:
                         return 0;
                 }
@@ -41,40 +41,33 @@ namespace Parameters
         public byte[] GetBytes()
         {
             List<byte> data = new List<byte>();
-            switch (Type)
+            data.Add((byte)this.Type);
+            switch (this.Type)
             {
-                case ParameterType.u8:
-                    data.Add(1);
-                    data.Add((byte)Value);
-                    return data.ToArray();
                 case ParameterType.s8:
-                    data.Add(2);
-                    data.Add((byte)Value);
+                    data.Add((byte)this.Value);
                     return data.ToArray();
-                case ParameterType.u16:
-                    data.Add(3);
-                    data.AddRange(BitConverter.GetBytes((ushort)Value).Reverse());
+                case ParameterType.u8:
+                    data.Add((byte)this.Value);
                     return data.ToArray();
                 case ParameterType.s16:
-                    data.Add(4);
-                    data.AddRange(BitConverter.GetBytes((short)Value).Reverse());
+                    data.AddRange(BitConverter.GetBytes((short)this.Value).Reverse());
                     return data.ToArray();
-                case ParameterType.u32:
-                    data.Add(5);
-                    data.AddRange(BitConverter.GetBytes((uint)Value).Reverse());
+                case ParameterType.u16:
+                    data.AddRange(BitConverter.GetBytes((ushort)this.Value).Reverse());
                     return data.ToArray();
                 case ParameterType.s32:
-                    data.Add(6);
-                    data.AddRange(BitConverter.GetBytes((int)Value).Reverse());
+                    data.AddRange(BitConverter.GetBytes((int)this.Value).Reverse());
+                    return data.ToArray();
+                case ParameterType.u32:
+                    data.AddRange(BitConverter.GetBytes((uint)this.Value).Reverse());
                     return data.ToArray();
                 case ParameterType.f32:
-                    data.Add(7);
-                    data.AddRange(BitConverter.GetBytes((float)Value).Reverse());
+                    data.AddRange(BitConverter.GetBytes((float)this.Value).Reverse());
                     return data.ToArray();
                 case ParameterType.str:
-                    data.Add(8);
-                    data.AddRange(BitConverter.GetBytes(((string)Value).Length).Reverse());
-                    data.AddRange(Encoding.ASCII.GetBytes((string)Value));
+                    data.AddRange(BitConverter.GetBytes(((string)this.Value).Length).Reverse());
+                    data.AddRange(Encoding.ASCII.GetBytes((string)this.Value));
                     return data.ToArray();
                 default:
                     return null;

--- a/SALT/PARAMS/ParamEntry.cs
+++ b/SALT/PARAMS/ParamEntry.cs
@@ -24,14 +24,14 @@ namespace SALT.PARAMS
             {
                 switch (this.Type)
                 {
-                    case ParamType.u8:
                     case ParamType.s8:
+                    case ParamType.u8:
                         return 2;
-                    case ParamType.u16:
                     case ParamType.s16:
+                    case ParamType.u16:
                         return 3;
-                    case ParamType.u32:
                     case ParamType.s32:
+                    case ParamType.u32:
                     case ParamType.f32:
                         return 5;
                     case ParamType.str:
@@ -45,43 +45,35 @@ namespace SALT.PARAMS
         public byte[] GetBytes()
         {
             List<byte> data = new List<byte>();
+            data.Add((byte)this.Type);
             switch (this.Type)
             {
-                case ParamType.u8:
-                    data.Add(1);
-                    data.Add((byte)this.Value);
-                    return data.ToArray();
                 case ParamType.s8:
-                    data.Add(2);
                     data.Add((byte)this.Value);
                     return data.ToArray();
-                case ParamType.u16:
-                    data.Add(3);
-                    data.AddRange(BitConverter.GetBytes((ushort)this.Value).Reverse());
+                case ParamType.u8:
+                    data.Add((byte)this.Value);
                     return data.ToArray();
                 case ParamType.s16:
-                    data.Add(4);
                     data.AddRange(BitConverter.GetBytes((short)this.Value).Reverse());
                     return data.ToArray();
-                case ParamType.u32:
-                    data.Add(5);
-                    data.AddRange(BitConverter.GetBytes((uint)this.Value).Reverse());
+                case ParamType.u16:
+                    data.AddRange(BitConverter.GetBytes((ushort)this.Value).Reverse());
                     return data.ToArray();
                 case ParamType.s32:
-                    data.Add(6);
                     data.AddRange(BitConverter.GetBytes((int)this.Value).Reverse());
                     return data.ToArray();
+                case ParamType.u32:
+                    data.AddRange(BitConverter.GetBytes((uint)this.Value).Reverse());
+                    return data.ToArray();
                 case ParamType.f32:
-                    data.Add(7);
                     data.AddRange(BitConverter.GetBytes((float)this.Value).Reverse());
                     return data.ToArray();
                 case ParamType.str:
-                    data.Add(8);
                     data.AddRange(BitConverter.GetBytes(((string)this.Value).Length).Reverse());
                     data.AddRange(Encoding.ASCII.GetBytes((string)this.Value));
                     return data.ToArray();
                 case ParamType.group:
-                    data.Add(0x20);
                     data.AddRange(((ParamGroup)this.Value).GetBytes());
                     return data.ToArray();
                 default:
@@ -93,12 +85,12 @@ namespace SALT.PARAMS
         {
             switch (this.Type)
             {
-                case ParamType.u8:
                 case ParamType.s8:
-                case ParamType.u16:
+                case ParamType.u8:
                 case ParamType.s16:
-                case ParamType.u32:
+                case ParamType.u16:
                 case ParamType.s32:
+                case ParamType.u32:
                     return $"0x{this.Value:X}";
                 case ParamType.f32:
                     return $"{this.Value:F}";

--- a/SALT/PARAMS/ParamFile.cs
+++ b/SALT/PARAMS/ParamFile.cs
@@ -34,23 +34,23 @@ namespace SALT.PARAMS
                         ParamType type = (ParamType)stream.ReadByte();
                         switch (type)
                         {
+                            case ParamType.s8:
+                                col.Add(new ParamEntry(reader.ReadSByte(), type));
+                                break;
                             case ParamType.u8:
                                 col.Add(new ParamEntry(reader.ReadByte(), type));
-                                break;
-                            case ParamType.s8:
-                                col.Add(new ParamEntry(reader.ReadByte(), type));
-                                break;
-                            case ParamType.u16:
-                                col.Add(new ParamEntry(reader.ReadUInt16().Reverse(), type));
                                 break;
                             case ParamType.s16:
                                 col.Add(new ParamEntry(reader.ReadInt16().Reverse(), type));
                                 break;
-                            case ParamType.u32:
-                                col.Add(new ParamEntry(reader.ReadUInt32().Reverse(), type));
+                            case ParamType.u16:
+                                col.Add(new ParamEntry(reader.ReadUInt16().Reverse(), type));
                                 break;
                             case ParamType.s32:
                                 col.Add(new ParamEntry(reader.ReadInt32().Reverse(), type));
+                                break;
+                            case ParamType.u32:
+                                col.Add(new ParamEntry(reader.ReadUInt32().Reverse(), type));
                                 break;
                             case ParamType.f32:
                                 col.Add(new ParamEntry(reader.ReadSingle().Reverse(), type));


### PR DESCRIPTION
I have changed the reading and writing of signed byte param values so that they are handled correctly, instead of being handled the same as unsigned bytes. I have also swapped the order of signed and unsigned value type-codes in all cases, to be consistent with the type-code order.

I have made these changes to both SALT's param support and PARAM.exe.